### PR TITLE
Add signingUrlQueryParams

### DIFF
--- a/src/DropzoneS3Uploader.js
+++ b/src/DropzoneS3Uploader.js
@@ -12,6 +12,8 @@ export default class DropzoneS3Uploader extends React.Component {
     s3Url: PropTypes.string,
     signing_url: PropTypes.string,
     signingUrl: PropTypes.string,
+    signing_url_query_params: PropTypes.object,
+    signingUrlQueryParams: PropTypes.object,
 
     children: PropTypes.element,
     headers: PropTypes.object,
@@ -75,6 +77,7 @@ export default class DropzoneS3Uploader extends React.Component {
     new S3Upload({ // eslint-disable-line
       files,
       signingUrl: this.props.signing_url || this.props.signingUrl || '/s3/sign',
+      signingUrlQueryParams: this.props.signing_url_query_params || this.props.signingUrlQueryParams || {},
       onProgress: this.onProgress,
       onFinishS3Put: this.onFinish,
       onError: this.onError,
@@ -143,4 +146,3 @@ export default class DropzoneS3Uploader extends React.Component {
     )
   }
 }
-


### PR DESCRIPTION
Usage

```
<DropzoneS3Uploader
  signingUrl="signed_url"
  signingUrlQueryParams={{ upload_type: 'avatar' }}
```

I tried using https://babeljs.io/repl/#?evaluate=true&presets=es2015%2Creact%2Cstage-1%2Cstage-2&code= but it came out vastly different than your lib file. Though the component still worked during my tests. Just didn't know if you would want it processed through there or not.
