### PR TITLE
use S3 uploader API to handle multiple upload callbacks

### DIFF
--- a/src/DropzoneS3Uploader.js
+++ b/src/DropzoneS3Uploader.js
@@ -88,8 +88,8 @@ export default class DropzoneS3Uploader extends React.Component {
     },
   }
 
-  onProgress = progress => {
-    this.props.onProgress && this.props.onProgress(progress)
+  onProgress = (progress, textState, file) => {
+    this.props.onProgress && this.props.onProgress(progress, textState, file)
     this.setState({progress})
   }
 
@@ -98,11 +98,14 @@ export default class DropzoneS3Uploader extends React.Component {
     this.setState({error: err, progress: null})
   }
 
-  onFinish = info => {
+  onFinish = (info, file) => {
     const filenames = this.state.filenames || []
-    const filename = info.filename
+    const filename = file.name
     filenames.push(filename)
-    this.setState({filename, filenames, error: null, progress: null}, () => this.props.onFinish && this.props.onFinish(info))
+    this.setState(
+      {filename, filenames, error: null, progress: null},
+      () => this.props.onFinish && this.props.onFinish(info, file)
+    )
   }
 
   handleDrop = (files, rejectedFiles) => {


### PR DESCRIPTION
Hey,

When use multiple uploading, It's hard to realize witch file uploading (uploaded) at the time. Let's use S3Uploader params and propagate them to actual callbacks.