### PR TITLE
Added ability to abort S3 upload, if necessary.

### DIFF
--- a/src/DropzoneS3Uploader.js
+++ b/src/DropzoneS3Uploader.js
@@ -84,6 +84,12 @@ export default class DropzoneS3Uploader extends React.Component {
   componentWillMount = () => this.setUploaderOptions(this.props)
   componentWillReceiveProps = props => this.setUploaderOptions(props)
 
+  abortUpload = () => {
+    if (this.uploader) {
+      this.uploader.abortUpload()
+    }
+  }
+
   setUploaderOptions = props => {
     this.setState({
       uploaderOptions: Object.assign({
@@ -127,7 +133,7 @@ export default class DropzoneS3Uploader extends React.Component {
       files,
       ...this.state.uploaderOptions,
     }
-    new S3Upload(options) // eslint-disable-line
+    this.uploader = new S3Upload(options)
     this.props.onDrop && this.props.onDrop(files, rejectedFiles)
   }
 


### PR DESCRIPTION
This doesn’t reset the progress of the component but simply stops the packages from being sent to the S3.