### PR TITLE
Return valid filename instead of undefined

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ import DropzoneS3Uploader from 'react-dropzone-s3-uploader'
 export default class S3Uploader extends React.Component {
 
   handleFinishedUpload = info => {
-    console.log('File uploaded with filename', info.filename)
+    console.log('File uploaded with filename', info.file.name)
     console.log('Access it on s3 at', info.fileUrl)
   }
 

--- a/src/DropzoneS3Uploader.js
+++ b/src/DropzoneS3Uploader.js
@@ -110,7 +110,7 @@ export default class DropzoneS3Uploader extends React.Component {
   handleFinish = (info, file) => {
     const uploadedFile = Object.assign({
       file,
-      fileUrl: this.fileUrl(this.props.s3Url, info.filename),
+      fileUrl: this.fileUrl(this.props.s3Url, file.name),
     }, info)
 
     const uploadedFiles = this.state.uploadedFiles


### PR DESCRIPTION
Previously, the filename was returning undefined, which resulted in no
image preview after upload, and an undefined `fileUrl` being
supplied to `onFinish`.

This fixes the issue by supplying the actual file name to
the fileUrl constructor.

Fixes: https://github.com/founderlab/react-dropzone-s3-uploader/issues/33