### PR TITLE
Do not silently drop file in onError handler

### DIFF
--- a/src/DropzoneS3Uploader.js
+++ b/src/DropzoneS3Uploader.js
@@ -102,8 +102,8 @@ export default class DropzoneS3Uploader extends React.Component {
     this.setState({progress})
   }
 
-  handleError = err => {
-    this.props.onError && this.props.onError(err)
+  handleError = (err, file) => {
+    this.props.onError && this.props.onError(err, file)
     this.setState({error: err, progress: null})
   }
 


### PR DESCRIPTION
Error handler does not indicate which file had an error (particularly important with multi-file uploads).

`react-s3-uploader` has support for this parameter so we just need to pass it on to it.