### PR TITLE
update readme - move s3Url

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,13 +50,14 @@ export default class S3Uploader extends React.Component {
   render() {
     const uploadOptions = {
       server: 'http://localhost:4000',
-      s3Url: 'https://my-bucket.s3.amazonaws.com',
       signingUrlQueryParams: {uploadType: 'avatar'},
     }
+    const s3Url = 'https://my-bucket.s3.amazonaws.com'
 
     return (
-      <DropzoneS3Uploader 
-        onFinish={this.handleFinishedUpload} 
+      <DropzoneS3Uploader
+        onFinish={this.handleFinishedUpload}
+        s3Url={s3Url}
         maxSize={1024 * 1024 * 5},
         upload={uploadOptions}
       />


### PR DESCRIPTION
move s3Url from react-s3-uploader to react-dropzone-s3-uploader 

It's not a prop for react-s3-uploader (https://github.com/odysseyscience/react-s3-uploader/blob/master/ReactS3Uploader.js#L12)

It's a required prop for dropzone (https://github.com/founderlab/react-dropzone-s3-uploader/blob/master/src/DropzoneS3Uploader.js#L10)