### PR TITLE
Add acl permissions support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dropzone-s3-uploader",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Drag and drop s3 file uploader via react-dropzone + react-s3-uploader",
   "main": "lib/index.js",
   "author": {
@@ -13,9 +13,9 @@
     "url": "https://github.com/founderlab/react-dropzone-s3-uploader"
   },
   "scripts": {
-    "prepublish": "rm -rf ./lib && babel ./src --ignore '/node_modules/' --out-dir ./lib",
-    "build": "rm -rf ./lib && babel ./src --ignore '/node_modules/' --out-dir ./lib",
-    "watch": "rm -rf ./lib && babel ./src --ignore '/node_modules/' --watch --out-dir ./lib",
+    "prepublish": "rm -rf ./lib && ./node_modules/babel/bin/babel.js ./src --ignore '/node_modules/' --out-dir ./lib",
+    "build": "rm -rf ./lib && ./node_modules/babel/bin/babel.js ./src --ignore '/node_modules/' --out-dir ./lib",
+    "watch": "rm -rf ./lib && ./node_modules/babel/bin/babel.js ./src --ignore '/node_modules/' --watch --out-dir ./lib",
     "test": "eval $(cat test/.env) mocha test/**/*.tests.js"
   },
   "dependencies": {

--- a/src/DropzoneS3Uploader.js
+++ b/src/DropzoneS3Uploader.js
@@ -11,6 +11,16 @@ export default class DropzoneS3Uploader extends React.Component {
     notDropzoneProps: PropTypes.array.isRequired,
     isImage: PropTypes.func.isRequired,
     passChildrenProps: PropTypes.bool,
+    aclPermissions: PropTypes.oneOf([
+      'private',
+      'public-read',
+      'public-read-write',
+      'aws-exec-read',
+      'authenticated-read',
+      'bucket-owner-read',
+      'bucket-owner-full-control',
+      'log-delivery-write',
+    ]),
 
     imageComponent: PropTypes.func,
     fileComponent: PropTypes.func,
@@ -42,6 +52,7 @@ export default class DropzoneS3Uploader extends React.Component {
 
   static defaultProps = {
     upload: {},
+    aclPermissions: 'public-read',
     className: 'react-dropzone-s3-uploader',
     passChildrenProps: true,
     isImage: filename => filename && filename.match(/\.(jpeg|jpg|gif|png|svg)/i),
@@ -89,7 +100,7 @@ export default class DropzoneS3Uploader extends React.Component {
         signingUrl: '/s3/sign',
         s3path: '',
         contentDisposition: 'auto',
-        uploadRequestHeaders: {'x-amz-acl': 'public-read'},
+        uploadRequestHeaders: {'x-amz-acl': props.aclPermissions },
         onFinishS3Put: this.handleFinish,
         onProgress: this.handleProgress,
         onError: this.handleError,


### PR DESCRIPTION
Add ability to configure ACL permissions

Right now, permissions are hard-coded to 'public-read'.  This change adds a new prop to DropzoneS3Uploader called aclPermissions.  The value is a string.  Any canned aws ACL should be valid, we are using 'private' for our purposes. http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl.

Also, we are specifying the directory for babel in our build commands.