### PR TITLE
Prevent onDrop from being overridden

### DIFF
--- a/src/DropzoneS3Uploader.js
+++ b/src/DropzoneS3Uploader.js
@@ -192,7 +192,7 @@ export default class DropzoneS3Uploader extends React.Component {
     }
 
     return (
-      <Dropzone ref={c => this._dropzone = c} onDrop={this.handleDrop} {...dropzoneProps}>
+      <Dropzone ref={c => this._dropzone = c} {...dropzoneProps} onDrop={this.handleDrop}>
         {content}
       </Dropzone>
     )


### PR DESCRIPTION
Currently, defining `onDrop` in props overrides the `Dropzone` component's `onDrop` parameter due to the spread props.

I believe that this should fix #46.