### PR TITLE
Update React Lifecycles to use UNSAFE_

### DIFF
--- a/src/DropzoneS3Uploader.js
+++ b/src/DropzoneS3Uploader.js
@@ -80,8 +80,8 @@ export default class DropzoneS3Uploader extends React.Component {
     this.state = {uploadedFiles}
   }
 
-  componentWillMount = () => this.setUploaderOptions(this.props)
-  componentWillReceiveProps = props => this.setUploaderOptions(props)
+   UNSAFE_componentWillMount = () => this.setUploaderOptions(this.props)
+   UNSAFE_componentWillReceiveProps = props => this.setUploaderOptions(props)
 
   setUploaderOptions = props => {
     this.setState({


### PR DESCRIPTION
**Overview**

React is deprecating `componentWillMount` and `componentWillReceiveProps` in v17 without adding `UNSAFE_` in front of them. This will fix errors and warning messages in newer versions of React.